### PR TITLE
Improve scroll sync by using onMouseEnter and onMouseLeave events

### DIFF
--- a/src/components/ScrollSyncBody/index.jsx
+++ b/src/components/ScrollSyncBody/index.jsx
@@ -5,20 +5,10 @@ import ScrollSyncRow from '../ScrollSyncRows/ScrollSyncRow';
 class ScrollSyncBody extends PureComponent {
   state = {
     scrollLeft: 0,
-    rowBeingScrolled: null,
   };
 
-  handleScrollEvent = (
-    { isScrollingOnSameRow, rowBeingScrolled, scrollLeft },
-    scrollEventCallback
-  ) => {
-    scrollEventCallback();
-
-    if (isScrollingOnSameRow) {
-      this.setState({ scrollLeft });
-    } else {
-      this.setState({ rowBeingScrolled, scrollLeft });
-    }
+  handleScrollEvent = ({ scrollLeft }) => {
+    this.setState({ scrollLeft });
   };
 
   renderHeaderRow = () => {
@@ -28,7 +18,7 @@ class ScrollSyncBody extends PureComponent {
       headerClassName,
       headerColumnClassName,
     } = this.props;
-    const { rowBeingScrolled, scrollLeft } = this.state;
+    const { scrollLeft } = this.state;
 
     return (
       <ScrollSyncRow
@@ -40,7 +30,6 @@ class ScrollSyncBody extends PureComponent {
         key="header"
         onScroll={this.handleScrollEvent}
         rowId={ScrollSyncRow.HEADER_ROW_ID}
-        rowBeingScrolled={rowBeingScrolled}
         scrollLeft={scrollLeft}
       />
     );
@@ -52,7 +41,7 @@ class ScrollSyncBody extends PureComponent {
 
   render() {
     const { rows, columns, rowClassName, columnClassName } = this.props;
-    const { rowBeingScrolled, scrollLeft } = this.state;
+    const { scrollLeft } = this.state;
 
     return (
       <Fragment>
@@ -65,7 +54,6 @@ class ScrollSyncBody extends PureComponent {
             className: rowClassName,
             columnClassName,
             columns,
-            rowBeingScrolled,
             scrollLeft,
             ...row.props,
           })

--- a/src/components/ScrollSyncRows/ScrollSyncRow/Sections/ScrollableSection/index.jsx
+++ b/src/components/ScrollSyncRows/ScrollSyncRow/Sections/ScrollableSection/index.jsx
@@ -11,6 +11,9 @@ const defaultSectionStyle = {
 
 class ScrollableSection extends PureComponent {
   rowId = -1;
+  state = {
+    showScrollTrack: false,
+  };
 
   constructor(props) {
     super(props);
@@ -21,32 +24,24 @@ class ScrollableSection extends PureComponent {
   }
 
   componentDidUpdate() {
-    this.preventChangingCurrentRow = true;
     this.scrollableArea.scrollLeft(this.props.scrollLeft);
   }
+
+  handleOnMouseEnter = () => this.setState({ showScrollTrack: true });
+
+  handleOnMouseLeave = () => this.setState({ showScrollTrack: false });
 
   handleOnScrollSection = () => {
     const scrollLeft = this.scrollableArea.getScrollLeft();
 
-    this.props.onScroll(
-      {
-        isScrollingOnSameRow: this.preventChangingCurrentRow,
-        rowBeingScrolled: this.rowId,
-        scrollLeft,
-      },
-      () => {
-        this.preventChangingCurrentRow = false;
-      }
-    );
+    this.props.onScroll({ scrollLeft });
   };
 
   renderScrollView = ({ style, ...props }) => {
-    const isScrollingCurrentRow = this.rowId === this.props.rowBeingScrolled;
+    const { showScrollTrack } = this.state;
     const showScrollTracks = { marginBottom: '0' };
     const hideScrollTracks = { marginBottom: '-18px' };
-    const customStyles = isScrollingCurrentRow
-      ? showScrollTracks
-      : hideScrollTracks;
+    const customStyles = showScrollTrack ? showScrollTracks : hideScrollTracks;
 
     return (
       <div
@@ -65,7 +60,11 @@ class ScrollableSection extends PureComponent {
     const { columns } = this.props;
 
     return (
-      <div style={defaultWrapperStyle}>
+      <div
+        id="scrollable-wrapper"
+        style={defaultWrapperStyle}
+        onMouseEnter={this.handleOnMouseEnter}
+        onMouseLeave={this.handleOnMouseLeave}>
         <Scrollbars
           renderView={this.renderScrollView}
           onScroll={this.handleOnScrollSection}

--- a/src/components/ScrollSyncRows/ScrollSyncRow/index.jsx
+++ b/src/components/ScrollSyncRows/ScrollSyncRow/index.jsx
@@ -104,14 +104,7 @@ class ScrollSyncRow extends PureComponent {
   };
 
   render() {
-    const {
-      rowId,
-      isSticky,
-      rowBeingScrolled,
-      scrollLeft,
-      onScroll,
-      className,
-    } = this.props;
+    const { isSticky, scrollLeft, onScroll, className } = this.props;
     const stickyStyleProps = isSticky ? stickyStyle : {};
     const styles = {
       ...defaultRowStyle,
@@ -122,9 +115,8 @@ class ScrollSyncRow extends PureComponent {
       <div className={className} style={styles}>
         <LeftStickySection columns={this.leftStickySection} />
         <ScrollableSection
-          rowId={rowId}
+          rowId={this.rowId}
           columns={this.scrollableSection}
-          rowBeingScrolled={rowBeingScrolled}
           onScroll={onScroll}
           scrollLeft={scrollLeft}
         />
@@ -140,7 +132,6 @@ ScrollSyncRow.propTypes = {
 };
 
 ScrollSyncRow.defaultProps = {
-  columns: [],
   className: '',
 };
 

--- a/src/test/ScrollSyncBody.test.jsx
+++ b/src/test/ScrollSyncBody.test.jsx
@@ -56,22 +56,12 @@ describe('ScrollSyncBody', () => {
       <ScrollSyncBody columns={columns} rows={rows} />
     );
     const HeaderRow = ScrollSyncBodyComponent.find('ScrollSyncRow').first();
-    const scrollEventCallback = jest.fn();
 
-    HeaderRow.prop('onScroll')(
-      {
-        isScrollingOnSameRow: true,
-        rowBeingScrolled: 0,
-        scrollLeft: 10,
-      },
-      scrollEventCallback
-    );
+    HeaderRow.prop('onScroll')({ scrollLeft: 10 });
 
     expect(ScrollSyncBodyComponent.state()).toEqual({
       scrollLeft: 10,
-      rowBeingScrolled: null,
     });
-    expect(scrollEventCallback).toHaveBeenCalled();
   });
 
   test('should update the row being scrolled when handleScrollEvent is called from a different row', () => {
@@ -81,25 +71,14 @@ describe('ScrollSyncBody', () => {
 
     ScrollSyncBodyComponent.setState({
       scrollLeft: 10,
-      rowBeingScrolled: 0,
     });
 
     const HeaderRow = ScrollSyncBodyComponent.find('ScrollSyncRow').first();
-    const scrollEventCallback = jest.fn();
 
-    HeaderRow.prop('onScroll')(
-      {
-        isScrollingOnSameRow: false,
-        rowBeingScrolled: 1,
-        scrollLeft: 20,
-      },
-      scrollEventCallback
-    );
+    HeaderRow.prop('onScroll')({ scrollLeft: 20 });
 
     expect(ScrollSyncBodyComponent.state()).toEqual({
       scrollLeft: 20,
-      rowBeingScrolled: 1,
     });
-    expect(scrollEventCallback).toHaveBeenCalled();
   });
 });

--- a/src/test/ScrollableSection.test.jsx
+++ b/src/test/ScrollableSection.test.jsx
@@ -40,4 +40,34 @@ describe('ScrollableSection', () => {
 
     expect(onScroll).toHaveBeenCalled();
   });
+
+  test('should show the scroll tracks when the mouse enters to the section', () => {
+    const ScrollableSectionComponent = shallow(
+      <ScrollableSection columns={[]} />
+    );
+    const ScrollableWrapper = ScrollableSectionComponent.find(
+      '#scrollable-wrapper'
+    );
+
+    ScrollableWrapper.prop('onMouseEnter')();
+
+    expect(ScrollableSectionComponent.state()).toEqual({
+      showScrollTrack: true,
+    });
+  });
+
+  test('should hide the scroll tracks when the mouse leaves the section', () => {
+    const ScrollableSectionComponent = shallow(
+      <ScrollableSection columns={[]} />
+    );
+    const ScrollableWrapper = ScrollableSectionComponent.find(
+      '#scrollable-wrapper'
+    );
+
+    ScrollableWrapper.prop('onMouseLeave')();
+
+    expect(ScrollableSectionComponent.state()).toEqual({
+      showScrollTrack: false,
+    });
+  });
 });

--- a/src/test/__snapshots__/ScrollSyncBody.test.jsx.snap
+++ b/src/test/__snapshots__/ScrollSyncBody.test.jsx.snap
@@ -26,7 +26,6 @@ exports[`ScrollSyncBody should pass the provided class names to the rows 1`] = `
       isSticky={false}
       key="header"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={0}
       scrollLeft={0}
     />
@@ -38,10 +37,22 @@ exports[`ScrollSyncBody should pass the provided class names to the rows 1`] = `
       className=""
       column="a"
       columnClassName="column-class-name"
-      columns={Array []}
+      columns={
+        Array [
+          <ScrollSyncColumn
+            className=""
+            name="a"
+            width="150px"
+          />,
+          <ScrollSyncColumn
+            className=""
+            name="b"
+            width="150px"
+          />,
+        ]
+      }
       key="0"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={1}
       scrollLeft={0}
     />
@@ -53,10 +64,22 @@ exports[`ScrollSyncBody should pass the provided class names to the rows 1`] = `
       className=""
       column="b"
       columnClassName="column-class-name"
-      columns={Array []}
+      columns={
+        Array [
+          <ScrollSyncColumn
+            className=""
+            name="a"
+            width="150px"
+          />,
+          <ScrollSyncColumn
+            className=""
+            name="b"
+            width="150px"
+          />,
+        ]
+      }
       key="1"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={2}
       scrollLeft={0}
     />
@@ -77,7 +100,6 @@ exports[`ScrollSyncBody should render its default content 1`] = `
       isSticky={false}
       key="header"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={0}
       scrollLeft={0}
     />
@@ -111,7 +133,6 @@ exports[`ScrollSyncBody should render the given columns and rows 1`] = `
       isSticky={false}
       key="header"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={0}
       scrollLeft={0}
     />
@@ -123,10 +144,22 @@ exports[`ScrollSyncBody should render the given columns and rows 1`] = `
       className=""
       column="a"
       columnClassName=""
-      columns={Array []}
+      columns={
+        Array [
+          <ScrollSyncColumn
+            className=""
+            name="a"
+            width="150px"
+          />,
+          <ScrollSyncColumn
+            className=""
+            name="b"
+            width="150px"
+          />,
+        ]
+      }
       key="0"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={1}
       scrollLeft={0}
     />
@@ -138,10 +171,22 @@ exports[`ScrollSyncBody should render the given columns and rows 1`] = `
       className=""
       column="b"
       columnClassName=""
-      columns={Array []}
+      columns={
+        Array [
+          <ScrollSyncColumn
+            className=""
+            name="a"
+            width="150px"
+          />,
+          <ScrollSyncColumn
+            className=""
+            name="b"
+            width="150px"
+          />,
+        ]
+      }
       key="1"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={2}
       scrollLeft={0}
     />
@@ -175,7 +220,6 @@ exports[`ScrollSyncBody should set isSticky when stickHeader is provided 1`] = `
       isSticky={true}
       key="header"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={0}
       scrollLeft={0}
     />
@@ -187,10 +231,22 @@ exports[`ScrollSyncBody should set isSticky when stickHeader is provided 1`] = `
       className=""
       column="a"
       columnClassName=""
-      columns={Array []}
+      columns={
+        Array [
+          <ScrollSyncColumn
+            className=""
+            name="a"
+            width="150px"
+          />,
+          <ScrollSyncColumn
+            className=""
+            name="b"
+            width="150px"
+          />,
+        ]
+      }
       key="0"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={1}
       scrollLeft={0}
     />
@@ -202,10 +258,22 @@ exports[`ScrollSyncBody should set isSticky when stickHeader is provided 1`] = `
       className=""
       column="b"
       columnClassName=""
-      columns={Array []}
+      columns={
+        Array [
+          <ScrollSyncColumn
+            className=""
+            name="a"
+            width="150px"
+          />,
+          <ScrollSyncColumn
+            className=""
+            name="b"
+            width="150px"
+          />,
+        ]
+      }
       key="1"
       onScroll={[Function]}
-      rowBeingScrolled={null}
       rowId={2}
       scrollLeft={0}
     />

--- a/src/test/__snapshots__/ScrollSyncRow.test.jsx.snap
+++ b/src/test/__snapshots__/ScrollSyncRow.test.jsx.snap
@@ -194,7 +194,7 @@ exports[`ScrollSyncRow should render its default content 1`] = `
   <ScrollableSection
     columns={Array []}
     onScroll={[Function]}
-    rowId="1"
+    rowId={1}
   />
   <RightStickySection
     columns={Array []}

--- a/src/test/__snapshots__/ScrollSyncTable.test.jsx.snap
+++ b/src/test/__snapshots__/ScrollSyncTable.test.jsx.snap
@@ -74,7 +74,6 @@ exports[`ScrollSyncTable should render the given columns and rows 1`] = `
       Array [
         <ScrollSyncRow
           className=""
-          columns={Array []}
         >
           <ScrollSyncCell
             column="a"

--- a/src/test/__snapshots__/ScrollableSection.test.jsx.snap
+++ b/src/test/__snapshots__/ScrollableSection.test.jsx.snap
@@ -2,6 +2,9 @@
 
 exports[`ScrollableSection should render its default content 1`] = `
 <div
+  id="scrollable-wrapper"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   style={
     Object {
       "flex": "1 1 auto",
@@ -31,6 +34,9 @@ exports[`ScrollableSection should render its default content 1`] = `
 
 exports[`ScrollableSection should render the given columns 1`] = `
 <div
+  id="scrollable-wrapper"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   style={
     Object {
       "flex": "1 1 auto",


### PR DESCRIPTION
Before I was using a state prop in the parent component `ScrollSyncBody` to keep the index of the row being scrolled and comparing in the other rows that the index passed as a prop was equal to the current rowId. That added poor performance and a dark code.